### PR TITLE
Make service config imports build-safe

### DIFF
--- a/app/api/auth/imagekit/route.ts
+++ b/app/api/auth/imagekit/route.ts
@@ -4,13 +4,27 @@ import { NextResponse } from "next/server";
 import { headers } from "next/headers";
 import ratelimit from "@/lib/ratelimit";
 
-const {
-  env: {
-    imagekit: { publicKey, privateKey, urlEndpoint },
-  },
-} = config;
+let imagekit: ImageKit | null = null;
 
-const imagekit = new ImageKit({ publicKey, privateKey, urlEndpoint });
+const getImageKit = () => {
+  if (imagekit) {
+    return imagekit;
+  }
+
+  const {
+    imagekit: { publicKey, privateKey, urlEndpoint },
+  } = config.env;
+
+  if (!publicKey || !privateKey || !urlEndpoint) {
+    throw new Error(
+      "ImageKit is not configured. Please check NEXT_PUBLIC_IMAGEKIT_PUBLIC_KEY, IMAGEKIT_PRIVATE_KEY, and NEXT_PUBLIC_IMAGEKIT_URL_ENDPOINT."
+    );
+  }
+
+  imagekit = new ImageKit({ publicKey, privateKey, urlEndpoint });
+
+  return imagekit;
+};
 
 export async function GET() {
   try {
@@ -37,7 +51,7 @@ export async function GET() {
     // However, rate limiting provides protection against abuse
     // Authenticated users get priority, but unauthenticated users can still use it for sign-up
 
-    return NextResponse.json(imagekit.getAuthenticationParameters());
+    return NextResponse.json(getImageKit().getAuthenticationParameters());
   } catch (error) {
     console.error("Error getting ImageKit authentication parameters:", error);
     return NextResponse.json(

--- a/database/drizzle.ts
+++ b/database/drizzle.ts
@@ -2,25 +2,44 @@ import config from "@/lib/config";
 import { drizzle } from "drizzle-orm/mysql2";
 import mysql from "mysql2/promise";
 
-if (!config.env.databaseUrl) {
-  throw new Error(
-    "No database connection string was provided. Please check your DATABASE_URL environment variable."
-  );
-}
+const missingDatabaseUrlMessage =
+  "No database connection string was provided. Please check your DATABASE_URL environment variable.";
 
-const createPool = () =>
-  mysql.createPool({
+const createMissingDatabaseUrlError = () =>
+  new Error(missingDatabaseUrlMessage);
+
+const createPool = () => {
+  if (!config.env.databaseUrl) {
+    throw createMissingDatabaseUrlError();
+  }
+
+  return mysql.createPool({
     uri: config.env.databaseUrl,
     connectionLimit: 10,
     waitForConnections: true,
     queueLimit: 0,
     enableKeepAlive: true,
   });
+};
 
 const createDb = (pool: mysql.Pool) =>
   drizzle({ client: pool, casing: "snake_case" });
 
 type Db = ReturnType<typeof createDb>;
+
+const createMissingDatabase = () =>
+  new Proxy(
+    {},
+    {
+      get(_target, property) {
+        if (property === "then") {
+          return undefined;
+        }
+
+        throw createMissingDatabaseUrlError();
+      },
+    }
+  ) as Db;
 
 declare global {
   // eslint-disable-next-line no-var
@@ -34,10 +53,14 @@ const globalForDb = globalThis as typeof globalThis & {
   __libraryDb?: Db;
 };
 
-const pool = globalForDb.__libraryPool ?? createPool();
-const db = globalForDb.__libraryDb ?? createDb(pool);
+const pool = config.env.databaseUrl
+  ? globalForDb.__libraryPool ?? createPool()
+  : undefined;
+const db = pool
+  ? globalForDb.__libraryDb ?? createDb(pool)
+  : createMissingDatabase();
 
-if (process.env.NODE_ENV !== "production") {
+if (process.env.NODE_ENV !== "production" && pool) {
   globalForDb.__libraryPool = pool;
   globalForDb.__libraryDb = db;
 }


### PR DESCRIPTION
## Summary

Make database and ImageKit setup import-safe so `next build` can collect route/page data without requiring production service credentials at module load time.

The database and ImageKit clients now initialize lazily and throw clear runtime configuration errors only when code actually tries to use them.

## Scope

- [ ] Frontend
- [x] Backend/API
- [ ] Database/Schema
- [x] Infrastructure/CI
- [ ] Documentation

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run build`
- [ ] Manual smoke test completed

## Performance Impact

- [x] No measurable perf impact expected
- [ ] Perf-sensitive paths changed and benchmarked

If benchmarked, include before/after numbers for at least one endpoint or page:

- Baseline:
- New:
- Delta:

## Security Checklist

- [x] No secrets added
- [x] Auth/authorization implications reviewed
- [x] Input validation and error handling reviewed

## Deployment Notes

- [x] No migration required
- [ ] Migration required (include rollback plan)
- [ ] Feature flag required

## Related Issues

Fixes #31
Fixes #30


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced ImageKit integration initialization performance
  * Improved database connection error handling with better validation messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->