### PR TITLE
Force admin routes to render dynamically

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -9,6 +9,8 @@ import { users } from "@/database/schema";
 import { eq } from "drizzle-orm";
 import { getSession } from "@/lib/session";
 
+export const dynamic = "force-dynamic";
+
 const Layout = async ({ children }: { children: ReactNode }) => {
   const session = await getSession();
 


### PR DESCRIPTION
## Summary

Mark the admin route tree as dynamic so admin pages do database-backed work at request time instead of during static page generation.

This preserves the existing admin/session guard behavior and prevents build-time database access for admin data.

Stacked on #33.

## Scope

- [ ] Frontend
- [x] Backend/API
- [ ] Database/Schema
- [x] Infrastructure/CI
- [ ] Documentation

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run build`
- [ ] Manual smoke test completed

## Performance Impact

- [x] No measurable perf impact expected
- [ ] Perf-sensitive paths changed and benchmarked

If benchmarked, include before/after numbers for at least one endpoint or page:

- Baseline:
- New:
- Delta:

## Security Checklist

- [x] No secrets added
- [x] Auth/authorization implications reviewed
- [x] Input validation and error handling reviewed

## Deployment Notes

- [x] No migration required
- [ ] Migration required (include rollback plan)
- [ ] Feature flag required

## Related Issues

Fixes #28
