### PR TITLE
Make service config imports build-safe

### DIFF
--- a/app/api/auth/imagekit/route.ts
+++ b/app/api/auth/imagekit/route.ts
@@ -4,13 +4,27 @@ import { NextResponse } from "next/server";
 import { headers } from "next/headers";
 import ratelimit from "@/lib/ratelimit";
 
-const {
-  env: {
-    imagekit: { publicKey, privateKey, urlEndpoint },
-  },
-} = config;
+let imagekit: ImageKit | null = null;
 
-const imagekit = new ImageKit({ publicKey, privateKey, urlEndpoint });
+const getImageKit = () => {
+  if (imagekit) {
+    return imagekit;
+  }
+
+  const {
+    imagekit: { publicKey, privateKey, urlEndpoint },
+  } = config.env;
+
+  if (!publicKey || !privateKey || !urlEndpoint) {
+    throw new Error(
+      "ImageKit is not configured. Please check NEXT_PUBLIC_IMAGEKIT_PUBLIC_KEY, IMAGEKIT_PRIVATE_KEY, and NEXT_PUBLIC_IMAGEKIT_URL_ENDPOINT."
+    );
+  }
+
+  imagekit = new ImageKit({ publicKey, privateKey, urlEndpoint });
+
+  return imagekit;
+};
 
 export async function GET() {
   try {
@@ -37,7 +51,7 @@ export async function GET() {
     // However, rate limiting provides protection against abuse
     // Authenticated users get priority, but unauthenticated users can still use it for sign-up
 
-    return NextResponse.json(imagekit.getAuthenticationParameters());
+    return NextResponse.json(getImageKit().getAuthenticationParameters());
   } catch (error) {
     console.error("Error getting ImageKit authentication parameters:", error);
     return NextResponse.json(

--- a/app/api/workflows/onboarding/route.ts
+++ b/app/api/workflows/onboarding/route.ts
@@ -2,7 +2,7 @@ import { serve } from "@upstash/workflow/nextjs";
 import { db } from "@/database/drizzle";
 import { users } from "@/database/schema";
 import { eq } from "drizzle-orm";
-import { sendEmail } from "@/lib/workflow";
+import { getWorkflowServeOptions, sendEmail } from "@/lib/workflow";
 
 export const runtime = "nodejs";
 
@@ -52,43 +52,46 @@ const getUserState = async (email: string): Promise<UserState> => {
   }
 };
 
-export const { POST } = serve<InitialData>(async (context) => {
-  const { email, fullName } = context.requestPayload;
+export const { POST } = serve<InitialData>(
+  async (context) => {
+    const { email, fullName } = context.requestPayload;
 
-  // Welcome Email
-  await context.run("new-signup", async () => {
-    await sendEmail({
-      email,
-      subject: "Welcome to the platform",
-      message: `Welcome ${fullName}!`,
-    });
-  });
-
-  await context.sleep("wait-for-3-days", 60 * 60 * 24 * 3);
-
-  while (true) {
-    const state = await context.run("check-user-state", async () => {
-      return await getUserState(email);
+    // Welcome Email
+    await context.run("new-signup", async () => {
+      await sendEmail({
+        email,
+        subject: "Welcome to the platform",
+        message: `Welcome ${fullName}!`,
+      });
     });
 
-    if (state === "non-active") {
-      await context.run("send-email-non-active", async () => {
-        await sendEmail({
-          email,
-          subject: "Are you still there?",
-          message: `Hey ${fullName}, we miss you!`,
-        });
+    await context.sleep("wait-for-3-days", 60 * 60 * 24 * 3);
+
+    while (true) {
+      const state = await context.run("check-user-state", async () => {
+        return await getUserState(email);
       });
-    } else if (state === "active") {
-      await context.run("send-email-active", async () => {
-        await sendEmail({
-          email,
-          subject: "Welcome back!",
-          message: `Welcome back ${fullName}!`,
+
+      if (state === "non-active") {
+        await context.run("send-email-non-active", async () => {
+          await sendEmail({
+            email,
+            subject: "Are you still there?",
+            message: `Hey ${fullName}, we miss you!`,
+          });
         });
-      });
+      } else if (state === "active") {
+        await context.run("send-email-active", async () => {
+          await sendEmail({
+            email,
+            subject: "Welcome back!",
+            message: `Welcome back ${fullName}!`,
+          });
+        });
+      }
+
+      await context.sleep("wait-for-1-month", 60 * 60 * 24 * 30);
     }
-
-    await context.sleep("wait-for-1-month", 60 * 60 * 24 * 30);
-  }
-});
+  },
+  getWorkflowServeOptions<InitialData>()
+);

--- a/database/drizzle.ts
+++ b/database/drizzle.ts
@@ -2,25 +2,44 @@ import config from "@/lib/config";
 import { drizzle } from "drizzle-orm/mysql2";
 import mysql from "mysql2/promise";
 
-if (!config.env.databaseUrl) {
-  throw new Error(
-    "No database connection string was provided. Please check your DATABASE_URL environment variable."
-  );
-}
+const missingDatabaseUrlMessage =
+  "No database connection string was provided. Please check your DATABASE_URL environment variable.";
 
-const createPool = () =>
-  mysql.createPool({
+const createMissingDatabaseUrlError = () =>
+  new Error(missingDatabaseUrlMessage);
+
+const createPool = () => {
+  if (!config.env.databaseUrl) {
+    throw createMissingDatabaseUrlError();
+  }
+
+  return mysql.createPool({
     uri: config.env.databaseUrl,
     connectionLimit: 10,
     waitForConnections: true,
     queueLimit: 0,
     enableKeepAlive: true,
   });
+};
 
 const createDb = (pool: mysql.Pool) =>
   drizzle({ client: pool, casing: "snake_case" });
 
 type Db = ReturnType<typeof createDb>;
+
+const createMissingDatabase = () =>
+  new Proxy(
+    {},
+    {
+      get(_target, property) {
+        if (property === "then") {
+          return undefined;
+        }
+
+        throw createMissingDatabaseUrlError();
+      },
+    }
+  ) as Db;
 
 declare global {
   // eslint-disable-next-line no-var
@@ -34,10 +53,14 @@ const globalForDb = globalThis as typeof globalThis & {
   __libraryDb?: Db;
 };
 
-const pool = globalForDb.__libraryPool ?? createPool();
-const db = globalForDb.__libraryDb ?? createDb(pool);
+const pool = config.env.databaseUrl
+  ? globalForDb.__libraryPool ?? createPool()
+  : undefined;
+const db = pool
+  ? globalForDb.__libraryDb ?? createDb(pool)
+  : createMissingDatabase();
 
-if (process.env.NODE_ENV !== "production") {
+if (process.env.NODE_ENV !== "production" && pool) {
   globalForDb.__libraryPool = pool;
   globalForDb.__libraryDb = db;
 }

--- a/database/redis.ts
+++ b/database/redis.ts
@@ -1,9 +1,34 @@
 import { Redis } from "@upstash/redis";
 import config from "@/lib/config";
 
-const redis = new Redis({
-  url: config.env.upstash.redisUrl,
-  token: config.env.upstash.redisToken,
-});
+const missingRedisConfigMessage =
+  "Upstash Redis is not configured. Please check UPSTASH_REDIS_URL and UPSTASH_REDIS_TOKEN.";
+
+const createMissingRedisConfigError = () => new Error(missingRedisConfigMessage);
+
+const createMissingRedis = () =>
+  new Proxy(
+    {},
+    {
+      get(_target, property) {
+        if (property === "then") {
+          return undefined;
+        }
+
+        throw createMissingRedisConfigError();
+      },
+    }
+  ) as Redis;
+
+const hasRedisConfig = Boolean(
+  config.env.upstash.redisUrl && config.env.upstash.redisToken
+);
+
+const redis = hasRedisConfig
+  ? new Redis({
+      url: config.env.upstash.redisUrl,
+      token: config.env.upstash.redisToken,
+    })
+  : createMissingRedis();
 
 export default redis;

--- a/lib/workflow.ts
+++ b/lib/workflow.ts
@@ -1,14 +1,87 @@
-import { Client as WorkflowClient } from "@upstash/workflow";
+import {
+  Client as WorkflowClient,
+  type TriggerOptions,
+  type WorkflowServeOptions,
+} from "@upstash/workflow";
 import { Client as QStashClient, resend } from "@upstash/qstash";
 import config from "@/lib/config";
 
-export const workflowClient = new WorkflowClient({
-  baseUrl: config.env.upstash.qstashUrl,
-  token: config.env.upstash.qstashToken,
-});
+let workflowClientInstance: WorkflowClient | null = null;
+let qstashClient: QStashClient | null = null;
 
-const qstashClient = new QStashClient({
-  token: config.env.upstash.qstashToken,
+const createMissingQStashConfigError = () =>
+  new Error(
+    "Upstash QStash is not configured. Please check QSTASH_URL and QSTASH_TOKEN."
+  );
+
+const getWorkflowClient = () => {
+  if (workflowClientInstance) {
+    return workflowClientInstance;
+  }
+
+  if (!config.env.upstash.qstashUrl || !config.env.upstash.qstashToken) {
+    throw createMissingQStashConfigError();
+  }
+
+  workflowClientInstance = new WorkflowClient({
+    baseUrl: config.env.upstash.qstashUrl,
+    token: config.env.upstash.qstashToken,
+  });
+
+  return workflowClientInstance;
+};
+
+const getQStashClient = () => {
+  if (qstashClient) {
+    return qstashClient;
+  }
+
+  if (!config.env.upstash.qstashToken) {
+    throw createMissingQStashConfigError();
+  }
+
+  qstashClient = new QStashClient({
+    token: config.env.upstash.qstashToken,
+  });
+
+  return qstashClient;
+};
+
+const getResendProvider = () => {
+  if (!config.env.resendToken) {
+    throw new Error(
+      "Resend is not configured. Please check RESEND_TOKEN before sending workflow email."
+    );
+  }
+
+  return resend({ token: config.env.resendToken });
+};
+
+const createMissingWorkflowQStashClient = () => {
+  const fail = async () => {
+    throw createMissingQStashConfigError();
+  };
+
+  return {
+    batch: fail,
+    batchJSON: fail,
+    publish: fail,
+    publishJSON: fail,
+    http: {},
+  } as NonNullable<WorkflowServeOptions["qstashClient"]>;
+};
+
+export const workflowClient = {
+  trigger: (params: TriggerOptions) => getWorkflowClient().trigger(params),
+};
+
+export const getWorkflowServeOptions = <
+  TInitialPayload = unknown,
+  TResult = unknown,
+>(): WorkflowServeOptions<TInitialPayload, TResult> => ({
+  qstashClient: config.env.upstash.qstashToken
+    ? getQStashClient()
+    : createMissingWorkflowQStashClient(),
 });
 
 export const sendEmail = async ({
@@ -20,10 +93,10 @@ export const sendEmail = async ({
   subject: string;
   message: string;
 }) => {
-  await qstashClient.publishJSON({
+  await getQStashClient().publishJSON({
     api: {
       name: "email",
-      provider: resend({ token: config.env.resendToken }),
+      provider: getResendProvider(),
     },
     body: {
       from: "JS Mastery <contact@adrianjsmastery.com>",


### PR DESCRIPTION
## Summary

Make database and ImageKit setup import-safe so `next build` can collect route/page data without requiring production service credentials at module load time.

The database and ImageKit clients now initialize lazily and throw clear runtime configuration errors only when code actually tries to use them.

## Scope

- [ ] Frontend
- [x] Backend/API
- [ ] Database/Schema
- [x] Infrastructure/CI
- [ ] Documentation

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run build`
- [ ] Manual smoke test completed

## Performance Impact

- [x] No measurable perf impact expected
- [ ] Perf-sensitive paths changed and benchmarked

If benchmarked, include before/after numbers for at least one endpoint or page:

- Baseline:
- New:
- Delta:

## Security Checklist

- [x] No secrets added
- [x] Auth/authorization implications reviewed
- [x] Input validation and error handling reviewed

## Deployment Notes

- [x] No migration required
- [ ] Migration required (include rollback plan)
- [ ] Feature flag required

## Related Issues

Fixes #31
Fixes #30


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and clearer diagnostics when image, database, Redis, or messaging credentials are missing, preventing hard crashes and making misconfigurations easier to identify.
* **Chores**
  * Deferred service client initialization and conditional setup to avoid failing at application startup when optional environment configuration is absent.
* **Behavior**
  * Onboarding and email workflows remain functionally unchanged but are now resilient to missing configuration and report explicit errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->