### PR TITLE
Lazy-load Upstash workflow clients

### DIFF
--- a/app/api/workflows/onboarding/route.ts
+++ b/app/api/workflows/onboarding/route.ts
@@ -2,7 +2,7 @@ import { serve } from "@upstash/workflow/nextjs";
 import { db } from "@/database/drizzle";
 import { users } from "@/database/schema";
 import { eq } from "drizzle-orm";
-import { sendEmail } from "@/lib/workflow";
+import { getWorkflowServeOptions, sendEmail } from "@/lib/workflow";
 
 export const runtime = "nodejs";
 
@@ -52,43 +52,46 @@ const getUserState = async (email: string): Promise<UserState> => {
   }
 };
 
-export const { POST } = serve<InitialData>(async (context) => {
-  const { email, fullName } = context.requestPayload;
+export const { POST } = serve<InitialData>(
+  async (context) => {
+    const { email, fullName } = context.requestPayload;
 
-  // Welcome Email
-  await context.run("new-signup", async () => {
-    await sendEmail({
-      email,
-      subject: "Welcome to the platform",
-      message: `Welcome ${fullName}!`,
-    });
-  });
-
-  await context.sleep("wait-for-3-days", 60 * 60 * 24 * 3);
-
-  while (true) {
-    const state = await context.run("check-user-state", async () => {
-      return await getUserState(email);
+    // Welcome Email
+    await context.run("new-signup", async () => {
+      await sendEmail({
+        email,
+        subject: "Welcome to the platform",
+        message: `Welcome ${fullName}!`,
+      });
     });
 
-    if (state === "non-active") {
-      await context.run("send-email-non-active", async () => {
-        await sendEmail({
-          email,
-          subject: "Are you still there?",
-          message: `Hey ${fullName}, we miss you!`,
-        });
+    await context.sleep("wait-for-3-days", 60 * 60 * 24 * 3);
+
+    while (true) {
+      const state = await context.run("check-user-state", async () => {
+        return await getUserState(email);
       });
-    } else if (state === "active") {
-      await context.run("send-email-active", async () => {
-        await sendEmail({
-          email,
-          subject: "Welcome back!",
-          message: `Welcome back ${fullName}!`,
+
+      if (state === "non-active") {
+        await context.run("send-email-non-active", async () => {
+          await sendEmail({
+            email,
+            subject: "Are you still there?",
+            message: `Hey ${fullName}, we miss you!`,
+          });
         });
-      });
+      } else if (state === "active") {
+        await context.run("send-email-active", async () => {
+          await sendEmail({
+            email,
+            subject: "Welcome back!",
+            message: `Welcome back ${fullName}!`,
+          });
+        });
+      }
+
+      await context.sleep("wait-for-1-month", 60 * 60 * 24 * 30);
     }
-
-    await context.sleep("wait-for-1-month", 60 * 60 * 24 * 30);
-  }
-});
+  },
+  getWorkflowServeOptions<InitialData>()
+);

--- a/database/redis.ts
+++ b/database/redis.ts
@@ -1,9 +1,34 @@
 import { Redis } from "@upstash/redis";
 import config from "@/lib/config";
 
-const redis = new Redis({
-  url: config.env.upstash.redisUrl,
-  token: config.env.upstash.redisToken,
-});
+const missingRedisConfigMessage =
+  "Upstash Redis is not configured. Please check UPSTASH_REDIS_URL and UPSTASH_REDIS_TOKEN.";
+
+const createMissingRedisConfigError = () => new Error(missingRedisConfigMessage);
+
+const createMissingRedis = () =>
+  new Proxy(
+    {},
+    {
+      get(_target, property) {
+        if (property === "then") {
+          return undefined;
+        }
+
+        throw createMissingRedisConfigError();
+      },
+    }
+  ) as Redis;
+
+const hasRedisConfig = Boolean(
+  config.env.upstash.redisUrl && config.env.upstash.redisToken
+);
+
+const redis = hasRedisConfig
+  ? new Redis({
+      url: config.env.upstash.redisUrl,
+      token: config.env.upstash.redisToken,
+    })
+  : createMissingRedis();
 
 export default redis;

--- a/lib/workflow.ts
+++ b/lib/workflow.ts
@@ -1,14 +1,87 @@
-import { Client as WorkflowClient } from "@upstash/workflow";
+import {
+  Client as WorkflowClient,
+  type TriggerOptions,
+  type WorkflowServeOptions,
+} from "@upstash/workflow";
 import { Client as QStashClient, resend } from "@upstash/qstash";
 import config from "@/lib/config";
 
-export const workflowClient = new WorkflowClient({
-  baseUrl: config.env.upstash.qstashUrl,
-  token: config.env.upstash.qstashToken,
-});
+let workflowClientInstance: WorkflowClient | null = null;
+let qstashClient: QStashClient | null = null;
 
-const qstashClient = new QStashClient({
-  token: config.env.upstash.qstashToken,
+const createMissingQStashConfigError = () =>
+  new Error(
+    "Upstash QStash is not configured. Please check QSTASH_URL and QSTASH_TOKEN."
+  );
+
+const getWorkflowClient = () => {
+  if (workflowClientInstance) {
+    return workflowClientInstance;
+  }
+
+  if (!config.env.upstash.qstashUrl || !config.env.upstash.qstashToken) {
+    throw createMissingQStashConfigError();
+  }
+
+  workflowClientInstance = new WorkflowClient({
+    baseUrl: config.env.upstash.qstashUrl,
+    token: config.env.upstash.qstashToken,
+  });
+
+  return workflowClientInstance;
+};
+
+const getQStashClient = () => {
+  if (qstashClient) {
+    return qstashClient;
+  }
+
+  if (!config.env.upstash.qstashToken) {
+    throw createMissingQStashConfigError();
+  }
+
+  qstashClient = new QStashClient({
+    token: config.env.upstash.qstashToken,
+  });
+
+  return qstashClient;
+};
+
+const getResendProvider = () => {
+  if (!config.env.resendToken) {
+    throw new Error(
+      "Resend is not configured. Please check RESEND_TOKEN before sending workflow email."
+    );
+  }
+
+  return resend({ token: config.env.resendToken });
+};
+
+const createMissingWorkflowQStashClient = () => {
+  const fail = async () => {
+    throw createMissingQStashConfigError();
+  };
+
+  return {
+    batch: fail,
+    batchJSON: fail,
+    publish: fail,
+    publishJSON: fail,
+    http: {},
+  } as NonNullable<WorkflowServeOptions["qstashClient"]>;
+};
+
+export const workflowClient = {
+  trigger: (params: TriggerOptions) => getWorkflowClient().trigger(params),
+};
+
+export const getWorkflowServeOptions = <
+  TInitialPayload = unknown,
+  TResult = unknown,
+>(): WorkflowServeOptions<TInitialPayload, TResult> => ({
+  qstashClient: config.env.upstash.qstashToken
+    ? getQStashClient()
+    : createMissingWorkflowQStashClient(),
 });
 
 export const sendEmail = async ({
@@ -20,10 +93,10 @@ export const sendEmail = async ({
   subject: string;
   message: string;
 }) => {
-  await qstashClient.publishJSON({
+  await getQStashClient().publishJSON({
     api: {
       name: "email",
-      provider: resend({ token: config.env.resendToken }),
+      provider: getResendProvider(),
     },
     body: {
       from: "JS Mastery <contact@adrianjsmastery.com>",


### PR DESCRIPTION
## Summary

Lazy-load Redis, Workflow, QStash, and Resend setup so importing API routes during `next build` does not construct unconfigured Upstash clients or print config warnings.

This keeps missing service configuration as an explicit runtime error when Redis/QStash/email work is actually attempted.

Stacked on #35.

## Scope

- [ ] Frontend
- [x] Backend/API
- [ ] Database/Schema
- [x] Infrastructure/CI
- [ ] Documentation

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run build`
- [ ] Manual smoke test completed

## Performance Impact

- [x] No measurable perf impact expected
- [ ] Perf-sensitive paths changed and benchmarked

If benchmarked, include before/after numbers for at least one endpoint or page:

- Baseline:
- New:
- Delta:

## Security Checklist

- [x] No secrets added
- [x] Auth/authorization implications reviewed
- [x] Input validation and error handling reviewed

## Deployment Notes

- [x] No migration required
- [ ] Migration required (include rollback plan)
- [ ] Feature flag required

## Related Issues

Fixes #29
