### PR TITLE
Seed guest login accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,13 @@ What this does:
 docker compose run --rm seed
 ```
 
+This also creates the sign-in page test accounts:
+
+| Role | Email | Password |
+| --- | --- | --- |
+| Guest User | `test@user.com` | `12345678` |
+| Guest Admin | `test@admin.com` | `12345678` |
+
 ### 4. Useful commands
 
 ```bash

--- a/database/seed.ts
+++ b/database/seed.ts
@@ -1,5 +1,7 @@
 import dummyBooks from "../dummybooks.json";
-import { books } from "@/database/schema";
+import { books, users } from "@/database/schema";
+import { sha256 } from "@noble/hashes/sha256";
+import { randomBytes } from "@noble/hashes/utils";
 import { drizzle } from "drizzle-orm/mysql2";
 import mysql from "mysql2/promise";
 import { config } from "dotenv";
@@ -13,10 +15,63 @@ const pool = mysql.createPool({
 });
 export const db = drizzle({ client: pool, casing: "snake_case" });
 
+const concatUint8Arrays = (a: Uint8Array, b: Uint8Array): Uint8Array => {
+  const c = new Uint8Array(a.length + b.length);
+  c.set(a, 0);
+  c.set(b, a.length);
+  return c;
+};
+
+const hashPassword = (password: string) => {
+  const salt = randomBytes(16);
+  const passwordBytes = new TextEncoder().encode(password);
+  const hashBuffer = sha256(concatUint8Arrays(passwordBytes, salt));
+
+  return `${Buffer.from(salt).toString("base64")}:${Buffer.from(hashBuffer).toString("base64")}`;
+};
+
+const seedGuestUsers = async () => {
+  const guestPassword = hashPassword("12345678");
+  const guestUsers = [
+    {
+      fullName: "Guest User",
+      email: "test@user.com",
+      universityId: 90000001,
+      password: guestPassword,
+      universityCard: "guest-user-card",
+      status: "APPROVED" as const,
+      role: "USER" as const,
+    },
+    {
+      fullName: "Guest Admin",
+      email: "test@admin.com",
+      universityId: 90000002,
+      password: guestPassword,
+      universityCard: "guest-admin-card",
+      status: "APPROVED" as const,
+      role: "ADMIN" as const,
+    },
+  ];
+
+  for (const guestUser of guestUsers) {
+    await db.insert(users).values(guestUser).onDuplicateKeyUpdate({
+      set: {
+        fullName: guestUser.fullName,
+        password: guestUser.password,
+        universityCard: guestUser.universityCard,
+        status: guestUser.status,
+        role: guestUser.role,
+      },
+    });
+  }
+};
+
 const seed = async () => {
   console.log("Seeding data...");
 
   try {
+    await seedGuestUsers();
+
     for (const book of dummyBooks) {
       await db.insert(books).values({
         ...book,


### PR DESCRIPTION
Fixes #43.

## What changed

- Seed creates approved Guest User and Guest Admin accounts that match the sign-in page selector.
- Guest passwords use the same salted SHA-256 format as normal signups.
- The Docker seed docs now list the guest credentials.

## Why

The sign-in page already offers Guest User and Guest Admin options, but a fresh local database did not include those accounts. Selecting them filled the form with credentials that could only fail.

## Validation

- `npm run typecheck`
- `npm run lint`
- Verified `test@admin.com` / `12345678` returns an authenticated session against the running Docker app.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Docker setup instructions now include explicit documentation of test credentials.
  * Added reference table displaying two guest account email addresses and passwords to streamline testing workflows.

* **New Features**
  * Two guest accounts are now available and configured for sign-in page testing and evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->