### PR TITLE
Fix PR size label permissions

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
 
     steps:
       - name: Apply size label


### PR DESCRIPTION
## Outcome

Grants the PR size labeler the narrow pull-request write scope required to attach labels while retaining read-only repository contents and the existing issue-label scope.

The repository default GITHUB_TOKEN remains read-only. This fixes the 403 Resource not accessible by integration failure seen on PR #130 without broadening permissions for unrelated jobs.

## Verification

- actionlint / workflow syntax validation
- git diff --check
- failure log traced to the pull request label attachment endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated project workflows to enable required pull request operations.
  * No changes to application functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->