### PR TITLE
fix: keep postcss override aligned with direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,6 @@
     "form-data": "^4.0.6",
     "sharp": "^0.35.3",
     "uuid": "^14.0.0",
-    "postcss": "^8.5.23"
+    "postcss": "$postcss"
   }
 }


### PR DESCRIPTION
## Summary

- replace the duplicated PostCSS override spec with npm's direct-dependency reference
- preserve transitive PostCSS alignment without blocking Dependabot patch updates
- fix Dependabot `dependency_file_not_resolvable` failures when the direct range changes

## Validation

- clean Node 24 `npm ci`: pass
- `npm audit --audit-level=low`: 0 vulnerabilities
- lint and TypeScript: pass
- Vitest: 127/127 pass

No package version or lockfile changes are included.