### PR TITLE
fix: make admin navigation viewport safe

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,9 +1,9 @@
 /**
  * Admin Dashboard Layout
- * 
+ *
  * This layout is the shell for all administrative pages (/admin/*).
  * It enforces strict admin-only access and provides the admin-specific sidebar and header.
- * 
+ *
  * @module app/admin/layout
  */
 
@@ -23,10 +23,10 @@ export const dynamic = "force-dynamic";
 
 /**
  * Admin layout component.
- * 
+ *
  * Uses the `requireAdmin` guard to ensure the user is authenticated and has the 'ADMIN' role.
  * Redirects unauthorized users to sign-in (if unauthenticated) or the home page (if not an admin).
- * 
+ *
  * @param {Object} props - Component properties
  * @param {ReactNode} props.children - Admin sub-page content
  */
@@ -45,14 +45,14 @@ const Layout = async ({ children }: { children: ReactNode }) => {
   }
 
   return (
-    <main className="admin-theme flex min-h-screen w-full flex-row">
+    <main className="admin-theme flex min-h-[100dvh] w-full flex-row">
       {/* Admin-specific sidebar for navigation */}
       <Sidebar session={guard.session} />
 
       <div className="admin-container">
         {/* Admin-specific header with search and user profile */}
         <Header session={guard.session} />
-        
+
         {/* Admin page content */}
         {children}
       </div>

--- a/components/admin/AdminNavLinks.tsx
+++ b/components/admin/AdminNavLinks.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { usePathname } from "next/navigation";
+
+import { adminSideBarLinks } from "@/constants";
+import { cn } from "@/lib/utils";
+
+interface AdminNavLinksProps {
+  onNavigate?: () => void;
+}
+
+const AdminNavLinks = ({ onNavigate }: AdminNavLinksProps) => {
+  const pathname = usePathname();
+
+  return (
+    <ul className="flex flex-col gap-1">
+      {adminSideBarLinks.map((link) => {
+        const isSelected =
+          pathname === link.route ||
+          (link.route !== "/admin" && pathname.startsWith(`${link.route}/`));
+
+        return (
+          <li key={link.route}>
+            <Link
+              href={link.route}
+              onClick={onNavigate}
+              aria-current={isSelected ? "page" : undefined}
+              className={cn(
+                "group flex min-h-12 w-full items-center gap-3 rounded-lg border border-transparent px-3 text-sm font-medium text-slate-700 transition-colors hover:bg-[var(--mundia-panel)] hover:text-[var(--mundia-navy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mundia-navy)] focus-visible:ring-offset-2",
+                isSelected &&
+                  "border-[var(--mundia-line)] bg-[var(--mundia-panel)] font-semibold text-[var(--mundia-navy)]",
+              )}
+            >
+              <span className="flex size-6 shrink-0 items-center justify-center">
+                <Image
+                  src={link.img}
+                  alt=""
+                  aria-hidden="true"
+                  width={20}
+                  height={20}
+                  className={cn(
+                    "size-5 object-contain opacity-70 transition-opacity group-hover:opacity-100",
+                    isSelected && "opacity-100",
+                  )}
+                />
+              </span>
+              <span className="min-w-0 truncate">{link.text}</span>
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default AdminNavLinks;

--- a/components/admin/AdminUserCard.tsx
+++ b/components/admin/AdminUserCard.tsx
@@ -1,0 +1,49 @@
+import type { Session } from "next-auth";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { cn, getInitials } from "@/lib/utils";
+
+interface AdminUserCardProps {
+  session: Session;
+  variant: "sidebar" | "mobile";
+}
+
+const AdminUserCard = ({ session, variant }: AdminUserCardProps) => {
+  const isMobile = variant === "mobile";
+
+  return (
+    <div
+      className={
+        isMobile
+          ? "flex min-w-0 items-center gap-3 rounded-lg bg-[var(--mundia-paper)] p-3"
+          : "user"
+      }
+    >
+      <Avatar className={isMobile ? "size-11" : "size-10"}>
+        <AvatarFallback className="bg-amber-100 text-sm text-[var(--mundia-ink)]">
+          {getInitials(session.user?.name || "Administrator")}
+        </AvatarFallback>
+      </Avatar>
+      <div className={cn("min-w-0", !isMobile && "flex-1")}>
+        <p
+          className={cn(
+            "truncate font-semibold text-[var(--mundia-ink)]",
+            isMobile && "text-sm",
+          )}
+        >
+          {session.user?.name || "Administrator"}
+        </p>
+        <p
+          className={cn(
+            "truncate text-xs text-[var(--mundia-muted)]",
+            isMobile && "mt-0.5",
+          )}
+        >
+          {session.user?.email}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default AdminUserCard;

--- a/components/admin/Header.tsx
+++ b/components/admin/Header.tsx
@@ -1,14 +1,15 @@
 /**
  * Admin Header Component
- * 
+ *
  * The specific navigational header for the administrator dashboard.
  * Displays the current session context and workspace identity.
- * 
+ *
  * @author Mundia Library Team
  * @version 1.0.0
  */
 
 import { Session } from "next-auth";
+import MobileNavigation from "@/components/admin/MobileNavigation";
 
 /**
  * Props for Admin Header
@@ -22,10 +23,10 @@ interface AdminHeaderProps {
 
 /**
  * Admin Header
- * 
- * Provides a specialized context for the administrative dashboard, 
+ *
+ * Provides a specialized context for the administrative dashboard,
  * signaling to the user that they are in a high-privilege workspace.
- * 
+ *
  * @param {AdminHeaderProps} props - Component properties
  * @returns {JSX.Element} The rendered admin header
  */
@@ -33,17 +34,21 @@ const Header = ({ session }: AdminHeaderProps) => {
   return (
     <header className="admin-header">
       {/* Title and User Context */}
-      <div className="space-y-1">
-        <h2 className="font-serif text-2xl font-normal tracking-tight text-[var(--mundia-ink)] sm:text-3xl">
-          Circulation desk
-        </h2>
-        <p className="text-sm text-slate-600 sm:text-base">
-          Signed in as {session?.user?.name || "administrator"}
-        </p>
+      <div className="flex min-w-0 flex-1 items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1">
+          <h2 className="font-serif text-2xl font-normal tracking-tight text-[var(--mundia-ink)] sm:text-3xl">
+            Circulation desk
+          </h2>
+          <p className="truncate text-sm text-slate-600 sm:text-base">
+            Signed in as {session.user?.name || "administrator"}
+          </p>
+        </div>
+
+        <MobileNavigation session={session} />
       </div>
 
       {/* Workspace Indicator Badge */}
-      <div className="rounded-lg border border-[var(--mundia-line)] bg-[var(--mundia-panel)] px-3 py-2 text-xs font-medium text-[var(--mundia-ink)]/70">
+      <div className="hidden shrink-0 rounded-lg border border-[var(--mundia-line)] bg-[var(--mundia-panel)] px-3 py-2 text-xs font-medium text-[var(--mundia-ink)]/70 md:block">
         Admin workspace
       </div>
     </header>

--- a/components/admin/MobileNavigation.tsx
+++ b/components/admin/MobileNavigation.tsx
@@ -4,9 +4,8 @@ import { useEffect, useRef, useState } from "react";
 import { Menu, X } from "lucide-react";
 import type { Session } from "next-auth";
 
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { getInitials } from "@/lib/utils";
 import AdminNavLinks from "@/components/admin/AdminNavLinks";
+import AdminUserCard from "@/components/admin/AdminUserCard";
 
 interface MobileNavigationProps {
   session: Session;
@@ -14,7 +13,6 @@ interface MobileNavigationProps {
 
 const MobileNavigation = ({ session }: MobileNavigationProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [isHydrated, setIsHydrated] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const dialogRef = useRef<HTMLDialogElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
@@ -25,7 +23,14 @@ const MobileNavigation = ({ session }: MobileNavigationProps) => {
   };
 
   useEffect(() => {
-    setIsHydrated(true);
+    const desktopViewport = window.matchMedia("(min-width: 768px)");
+    const closeAtDesktop = (event: MediaQueryListEvent | MediaQueryList) => {
+      if (event.matches) setIsOpen(false);
+    };
+
+    closeAtDesktop(desktopViewport);
+    desktopViewport.addEventListener("change", closeAtDesktop);
+    return () => desktopViewport.removeEventListener("change", closeAtDesktop);
   }, []);
 
   useEffect(() => {
@@ -54,8 +59,7 @@ const MobileNavigation = ({ session }: MobileNavigationProps) => {
         ref={triggerRef}
         type="button"
         onClick={() => setIsOpen(true)}
-        disabled={!isHydrated}
-        className="flex size-11 shrink-0 items-center justify-center rounded-lg border border-[var(--mundia-line)] bg-[var(--mundia-paper)] text-[var(--mundia-ink)] transition-colors hover:border-[var(--mundia-navy)] hover:text-[var(--mundia-navy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mundia-navy)] disabled:opacity-60 md:hidden"
+        className="flex size-11 shrink-0 items-center justify-center rounded-lg border border-[var(--mundia-line)] bg-[var(--mundia-paper)] text-[var(--mundia-ink)] transition-colors hover:border-[var(--mundia-navy)] hover:text-[var(--mundia-navy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mundia-navy)] md:hidden"
         aria-label="Open admin navigation"
         aria-expanded={isOpen}
         aria-controls="admin-mobile-navigation"
@@ -113,21 +117,7 @@ const MobileNavigation = ({ session }: MobileNavigationProps) => {
           </nav>
 
           <div className="shrink-0 border-t border-[var(--mundia-line)] p-4">
-            <div className="flex min-w-0 items-center gap-3 rounded-lg bg-[var(--mundia-paper)] p-3">
-              <Avatar className="size-11">
-                <AvatarFallback className="bg-amber-100 text-sm text-[var(--mundia-ink)]">
-                  {getInitials(session.user?.name || "Administrator")}
-                </AvatarFallback>
-              </Avatar>
-              <div className="min-w-0">
-                <p className="truncate text-sm font-semibold text-[var(--mundia-ink)]">
-                  {session.user?.name || "Administrator"}
-                </p>
-                <p className="mt-0.5 truncate text-xs text-[var(--mundia-muted)]">
-                  {session.user?.email}
-                </p>
-              </div>
-            </div>
+            <AdminUserCard session={session} variant="mobile" />
           </div>
         </div>
       </dialog>

--- a/components/admin/MobileNavigation.tsx
+++ b/components/admin/MobileNavigation.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Menu, X } from "lucide-react";
+import type { Session } from "next-auth";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { getInitials } from "@/lib/utils";
+import AdminNavLinks from "@/components/admin/AdminNavLinks";
+
+interface MobileNavigationProps {
+  session: Session;
+}
+
+const MobileNavigation = ({ session }: MobileNavigationProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isHydrated, setIsHydrated] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  const closeNavigation = () => {
+    setIsOpen(false);
+    requestAnimationFrame(() => triggerRef.current?.focus());
+  };
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (!isOpen) {
+      if (dialog.open) dialog.close();
+      return;
+    }
+
+    if (!dialog.open) dialog.showModal();
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    closeButtonRef.current?.focus();
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setIsOpen(true)}
+        disabled={!isHydrated}
+        className="flex size-11 shrink-0 items-center justify-center rounded-lg border border-[var(--mundia-line)] bg-[var(--mundia-paper)] text-[var(--mundia-ink)] transition-colors hover:border-[var(--mundia-navy)] hover:text-[var(--mundia-navy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mundia-navy)] disabled:opacity-60 md:hidden"
+        aria-label="Open admin navigation"
+        aria-expanded={isOpen}
+        aria-controls="admin-mobile-navigation"
+      >
+        <Menu className="size-5" aria-hidden="true" />
+      </button>
+
+      <dialog
+        ref={dialogRef}
+        id="admin-mobile-navigation"
+        aria-labelledby="admin-mobile-navigation-title"
+        onCancel={(event) => {
+          event.preventDefault();
+          closeNavigation();
+        }}
+        className="admin-mobile-navigation-dialog fixed inset-0 z-50 m-0 h-dvh w-screen max-w-none border-0 bg-transparent p-0 md:hidden"
+      >
+        <button
+          type="button"
+          className="fixed inset-0 cursor-default"
+          onClick={closeNavigation}
+          aria-hidden="true"
+          tabIndex={-1}
+        />
+
+        <div className="relative z-10 flex h-full w-[min(88vw,22rem)] flex-col overflow-hidden border-r border-[var(--mundia-line)] bg-[var(--mundia-surface)] pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)]">
+          <div className="flex min-h-16 shrink-0 items-center justify-between border-b border-[var(--mundia-line)] px-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--mundia-muted)]">
+                Mundiapolis Library
+              </p>
+              <h2
+                id="admin-mobile-navigation-title"
+                className="mt-0.5 font-serif text-xl text-[var(--mundia-ink)]"
+              >
+                Admin navigation
+              </h2>
+            </div>
+            <button
+              ref={closeButtonRef}
+              type="button"
+              onClick={closeNavigation}
+              className="flex size-11 shrink-0 items-center justify-center rounded-lg text-[var(--mundia-ink)] transition-colors hover:bg-[var(--mundia-panel)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mundia-navy)]"
+              aria-label="Close admin navigation"
+            >
+              <X className="size-5" aria-hidden="true" />
+            </button>
+          </div>
+
+          <nav
+            className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 py-4"
+            aria-label="Admin navigation"
+          >
+            <AdminNavLinks onNavigate={closeNavigation} />
+          </nav>
+
+          <div className="shrink-0 border-t border-[var(--mundia-line)] p-4">
+            <div className="flex min-w-0 items-center gap-3 rounded-lg bg-[var(--mundia-paper)] p-3">
+              <Avatar className="size-11">
+                <AvatarFallback className="bg-amber-100 text-sm text-[var(--mundia-ink)]">
+                  {getInitials(session.user?.name || "Administrator")}
+                </AvatarFallback>
+              </Avatar>
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold text-[var(--mundia-ink)]">
+                  {session.user?.name || "Administrator"}
+                </p>
+                <p className="mt-0.5 truncate text-xs text-[var(--mundia-muted)]">
+                  {session.user?.email}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </dialog>
+    </>
+  );
+};
+
+export default MobileNavigation;

--- a/components/admin/Sidebar.tsx
+++ b/components/admin/Sidebar.tsx
@@ -1,21 +1,20 @@
 /**
  * Admin Sidebar Component
- * 
+ *
  * The primary vertical navigation for the administrator dashboard.
  * Includes logo branding, dynamic navigational links, and a user profile footer.
- * 
+ *
  * @author Mundia Library Team
  * @version 1.0.0
  */
 
 "use client";
 
-import { adminSideBarLinks } from "@/constants";
 import Link from "next/link";
-import { cn, getInitials } from "@/lib/utils";
-import { usePathname } from "next/navigation";
+import { getInitials } from "@/lib/utils";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Session } from "next-auth";
+import AdminNavLinks from "@/components/admin/AdminNavLinks";
 
 /**
  * Props for Admin Sidebar
@@ -29,102 +28,56 @@ interface AdminSidebarProps {
 
 /**
  * Sidebar
- * 
+ *
  * Client-side component that manages the administrative navigation state.
  * Automatically highlights the active route based on the current pathname.
- * 
+ *
  * @param {AdminSidebarProps} props - Component properties
  * @returns {JSX.Element} The rendered admin sidebar
  */
 const Sidebar = ({ session }: AdminSidebarProps) => {
-  const pathname = usePathname();
-
   return (
-    <div className="admin-sidebar">
-      <div>
+    <aside className="admin-sidebar" aria-label="Admin workspace sidebar">
+      <div className="flex min-h-0 flex-1 flex-col">
         {/* Responsive Logo Section */}
-        <Link href="/" className="logo">
-          {/* Small Mark for mobile/tight spaces */}
-          <img
-            src="/images/mundiapolis-mark.png"
-            alt="Mundiapolis Library"
-            height={40}
-            width={40}
-            className="h-10 w-10 object-contain sm:hidden"
-          />
-          {/* Full Logo for desktop */}
+        <Link href="/admin" className="logo" aria-label="Admin dashboard home">
           <img
             src="/images/mundiapolis-logo-transparent.png"
-            alt=""
+            alt="Mundiapolis Library"
             height={50}
             width={161}
-            className="hidden h-auto w-[161px] object-contain sm:block"
+            className="h-auto w-[161px] object-contain"
           />
           <h1 className="sr-only">Mundiapolis Library</h1>
         </Link>
 
         {/* Primary Navigation Links */}
-        <div className="my-2 flex flex-col gap-1.5 sm:gap-2">
-          {adminSideBarLinks.map((link) => {
-            /**
-             * ACTIVE LINK LOGIC:
-             * Highlights a link if it matches the current path exactly, 
-             * or if the current path starts with the link's route (for sub-pages).
-             */
-            const isSelected =
-              (link.route !== "/admin" &&
-                pathname.includes(link.route) &&
-                link.route.length > 1) ||
-              pathname === link.route;
-
-            return (
-              <Link href={link.route} key={link.route}>
-                <div className={cn("link", isSelected && "is-active")}>
-                  {/* Menu Icon */}
-                  <div className="relative size-4 sm:size-5">
-                    <img
-                      src={link.img}
-                      alt="icon"
-                      className={cn(
-                        "object-contain opacity-75",
-                        isSelected && "opacity-100",
-                      )}
-                      style={{ width: "100%", height: "100%" }} 
-                    />
-                  </div>
-
-                  {/* Menu Label - hidden on mobile viewports */}
-                  <p
-                    className={cn(
-                      "hidden sm:block",
-                      isSelected
-                        ? "font-semibold text-[var(--mundia-navy)]"
-                        : "text-slate-700",
-                    )}
-                  >
-                    {link.text}
-                  </p>
-                </div>
-              </Link>
-            );
-          })}
-        </div>
+        <nav
+          className="mt-4 min-h-0 flex-1 overflow-y-auto overscroll-contain pr-1"
+          aria-label="Admin navigation"
+        >
+          <AdminNavLinks />
+        </nav>
       </div>
 
       {/* User Profile Footer Section */}
       <div className="user">
-        <Avatar className="size-8 sm:size-10">
-          <AvatarFallback className="bg-amber-100 text-xs sm:text-sm">
-            {getInitials(session?.user?.name || "IN")}
+        <Avatar className="size-10">
+          <AvatarFallback className="bg-amber-100 text-sm text-[var(--mundia-ink)]">
+            {getInitials(session.user?.name || "Administrator")}
           </AvatarFallback>
         </Avatar>
 
-        <div className="hidden flex-col sm:flex">
-          <p className="font-semibold text-slate-900">{session?.user?.name}</p>
-          <p className="text-xs text-slate-600">{session?.user?.email}</p>
+        <div className="min-w-0 flex-1">
+          <p className="truncate font-semibold text-slate-900">
+            {session.user?.name || "Administrator"}
+          </p>
+          <p className="truncate text-xs text-slate-600">
+            {session.user?.email}
+          </p>
         </div>
       </div>
-    </div>
+    </aside>
   );
 };
 

--- a/components/admin/Sidebar.tsx
+++ b/components/admin/Sidebar.tsx
@@ -8,13 +8,10 @@
  * @version 1.0.0
  */
 
-"use client";
-
 import Link from "next/link";
-import { getInitials } from "@/lib/utils";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { Session } from "next-auth";
+import type { Session } from "next-auth";
 import AdminNavLinks from "@/components/admin/AdminNavLinks";
+import AdminUserCard from "@/components/admin/AdminUserCard";
 
 /**
  * Props for Admin Sidebar
@@ -29,8 +26,8 @@ interface AdminSidebarProps {
 /**
  * Sidebar
  *
- * Client-side component that manages the administrative navigation state.
- * Automatically highlights the active route based on the current pathname.
+ * Server-rendered navigation shell. AdminNavLinks owns client-side active-route
+ * highlighting so the rest of the sidebar does not need to hydrate.
  *
  * @param {AdminSidebarProps} props - Component properties
  * @returns {JSX.Element} The rendered admin sidebar
@@ -61,22 +58,7 @@ const Sidebar = ({ session }: AdminSidebarProps) => {
       </div>
 
       {/* User Profile Footer Section */}
-      <div className="user">
-        <Avatar className="size-10">
-          <AvatarFallback className="bg-amber-100 text-sm text-[var(--mundia-ink)]">
-            {getInitials(session.user?.name || "Administrator")}
-          </AvatarFallback>
-        </Avatar>
-
-        <div className="min-w-0 flex-1">
-          <p className="truncate font-semibold text-slate-900">
-            {session.user?.name || "Administrator"}
-          </p>
-          <p className="truncate text-xs text-slate-600">
-            {session.user?.email}
-          </p>
-        </div>
-      </div>
+      <AdminUserCard session={session} variant="sidebar" />
     </aside>
   );
 };

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -58,7 +58,7 @@ export const adminSideBarLinks = [
     text: "Borrow Requests",
   },
   {
-    img: "/icons/admin/bookmark.svg",
+    img: "/icons/admin/renewal.svg",
     route: "/admin/renewal-requests",
     text: "Renewal Requests",
   },

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,9 +1,9 @@
 /**
  * Application Constants
- * 
- * This module serves as the single source of truth for static UI text, 
+ *
+ * This module serves as the single source of truth for static UI text,
  * navigation configurations, and development-only sample data.
- * 
+ *
  * Using constants ensures:
  * - Consistency across forms and navigation menus.
  * - Easier localization and global UI updates.
@@ -56,6 +56,11 @@ export const adminSideBarLinks = [
     img: "/icons/admin/bookmark.svg",
     route: "/admin/book-requests",
     text: "Borrow Requests",
+  },
+  {
+    img: "/icons/admin/bookmark.svg",
+    route: "/admin/renewal-requests",
+    text: "Renewal Requests",
   },
   {
     img: "/icons/admin/user.svg",

--- a/public/icons/admin/renewal.svg
+++ b/public/icons/admin/renewal.svg
@@ -1,0 +1,7 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2.25" y="3.75" width="15.5" height="13.5" rx="2.25" stroke="#8C8E98" stroke-width="1.25"/>
+  <path d="M2.75 7.5H17.25" stroke="#8C8E98" stroke-width="1.25" stroke-linecap="round"/>
+  <path d="M6 2.25V5.25M14 2.25V5.25" stroke="#8C8E98" stroke-width="1.25" stroke-linecap="round"/>
+  <path d="M13.6 11.3C13.15 10.45 12.25 9.875 11.225 9.875C9.75 9.875 8.55 11.075 8.55 12.55C8.55 14.025 9.75 15.225 11.225 15.225C12.25 15.225 13.15 14.65 13.6 13.8" stroke="#8C8E98" stroke-width="1.25" stroke-linecap="round"/>
+  <path d="M12.35 11.3H13.75V9.9" stroke="#8C8E98" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/styles/admin.css
+++ b/styles/admin.css
@@ -232,9 +232,9 @@
   /* Sidebar */
   .admin-sidebar {
     @apply sticky top-0 z-40 hidden w-[248px] shrink-0 flex-col border-r px-5 pt-8 md:flex lg:w-[264px] lg:pt-10;
+
     height: 100vh;
     height: 100dvh;
-    min-height: 100svh;
     align-self: flex-start;
     padding-bottom: max(1.25rem, env(safe-area-inset-bottom));
     border-color: var(--mundia-line);
@@ -247,13 +247,9 @@
     border-color: var(--mundia-line);
   }
 
-  .admin-sidebar .logo h1 {
-    @apply text-xl font-normal text-[var(--mundia-ink)] max-md:hidden;
-    font-family: var(--font-heading);
-  }
-
   .admin-sidebar .user {
     @apply mt-4 flex w-full shrink-0 items-center gap-3 rounded-lg border px-3 py-3;
+
     border-color: var(--mundia-line);
     background: var(--mundia-paper);
   }

--- a/styles/admin.css
+++ b/styles/admin.css
@@ -212,7 +212,7 @@
 
   /* Header */
   .admin-header {
-    @apply flex lg:items-end items-start justify-between lg:flex-row flex-col gap-5 sm:mb-10 mb-5 rounded-lg border px-4 py-4 sm:px-6 sm:py-5;
+    @apply mb-5 flex items-center justify-between gap-4 rounded-lg border px-4 py-4 sm:mb-10 sm:px-6 sm:py-5;
     border-color: var(--mundia-line);
     background: var(--mundia-surface);
     box-shadow: none;
@@ -231,14 +231,19 @@
 
   /* Sidebar */
   .admin-sidebar {
-    @apply sticky top-0 z-40 flex h-screen w-[82px] shrink-0 flex-col justify-between overflow-y-auto border-r px-2 pb-5 pt-8 sm:w-[248px] sm:px-5 sm:pt-10 lg:w-[264px];
+    @apply sticky top-0 z-40 hidden w-[248px] shrink-0 flex-col border-r px-5 pt-8 md:flex lg:w-[264px] lg:pt-10;
+    height: 100vh;
+    height: 100dvh;
+    min-height: 100svh;
+    align-self: flex-start;
+    padding-bottom: max(1.25rem, env(safe-area-inset-bottom));
     border-color: var(--mundia-line);
     background: var(--mundia-surface);
     box-shadow: none;
   }
 
   .admin-sidebar .logo {
-    @apply flex cursor-pointer flex-row items-center justify-center gap-2 border-b pb-8 transition-all duration-200 hover:opacity-80 sm:justify-start sm:pb-10;
+    @apply flex shrink-0 cursor-pointer items-center border-b pb-8 transition-opacity duration-200 hover:opacity-80 lg:pb-10;
     border-color: var(--mundia-line);
   }
 
@@ -247,23 +252,14 @@
     font-family: var(--font-heading);
   }
 
-  .admin-sidebar .link {
-    @apply flex w-full flex-row items-center justify-center gap-2 rounded-none border-l border-transparent px-2 py-3.5 transition-colors hover:bg-transparent sm:justify-start sm:px-4;
-  }
-
-  .admin-sidebar .link.is-active {
-    border-left-color: var(--mundia-navy);
-    color: var(--mundia-navy);
-  }
-
-  .admin-sidebar .link p {
-    @apply text-base font-medium max-md:hidden;
-  }
-
   .admin-sidebar .user {
-    @apply my-6 flex w-full flex-row items-center justify-center gap-2 rounded-lg border px-2 py-2 sm:my-8 sm:justify-start sm:px-4;
+    @apply mt-4 flex w-full shrink-0 items-center gap-3 rounded-lg border px-3 py-3;
     border-color: var(--mundia-line);
     background: var(--mundia-paper);
+  }
+
+  .admin-mobile-navigation-dialog::backdrop {
+    background: oklch(15% 0.025 255 / 0.42);
   }
 
   /* User Card */

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -154,6 +154,7 @@ test("admin workspace uses a viewport-safe responsive navigation", async ({
   const navigationDialog = page.getByRole("dialog", {
     name: "Admin navigation",
   });
+  const navigationDialogElement = page.locator("#admin-mobile-navigation");
   await expect(navigationDialog).toBeVisible();
   expect(
     await navigationDialog.evaluate((element) => element.matches(":modal")),
@@ -171,8 +172,22 @@ test("admin workspace uses a viewport-safe responsive navigation", async ({
   await expect(page).toHaveURL(/\/admin\/account-requests/);
   await expect(navigationDialog).not.toBeVisible();
 
+  await navigationTrigger.click();
+  await expect(navigationDialog).toBeVisible();
+  await expect
+    .poll(() => page.evaluate(() => document.body.style.overflow))
+    .toBe("hidden");
+
   await page.setViewportSize({ width: 1024, height: 700 });
-  await page.goto("/admin");
+  await expect(navigationDialog).not.toBeVisible();
+  await expect
+    .poll(() =>
+      navigationDialogElement.evaluate((element) => element.matches(":modal")),
+    )
+    .toBe(false);
+  await expect
+    .poll(() => page.evaluate(() => document.body.style.overflow))
+    .not.toBe("hidden");
   await expect(page.locator(".admin-sidebar")).toBeVisible();
   await expect(navigationTrigger).toBeHidden();
 
@@ -180,11 +195,11 @@ test("admin workspace uses a viewport-safe responsive navigation", async ({
     .locator(".admin-sidebar")
     .evaluate((element) => ({
       top: element.getBoundingClientRect().top,
-      bottom: element.getBoundingClientRect().bottom,
       height: element.getBoundingClientRect().height,
       viewportHeight: window.innerHeight,
     }));
-  expect(sidebarGeometry.top).toBe(0);
-  expect(sidebarGeometry.bottom).toBe(sidebarGeometry.viewportHeight);
-  expect(sidebarGeometry.height).toBe(sidebarGeometry.viewportHeight);
+  expect(Math.abs(sidebarGeometry.top)).toBeLessThanOrEqual(1);
+  expect(
+    Math.abs(sidebarGeometry.height - sidebarGeometry.viewportHeight),
+  ).toBeLessThanOrEqual(1);
 });

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -5,12 +5,22 @@ const user = {
   password: process.env.E2E_USER_PASSWORD,
 };
 
-const signIn = async (page: Page) => {
-  if (!user.email || !user.password) throw new Error("Missing E2E credentials");
+const admin = {
+  email: process.env.E2E_ADMIN_EMAIL,
+  password: process.env.E2E_ADMIN_PASSWORD,
+};
+
+const signIn = async (
+  page: Page,
+  credentials: { email?: string; password?: string } = user,
+) => {
+  if (!credentials.email || !credentials.password) {
+    throw new Error("Missing E2E credentials");
+  }
 
   await page.goto("/sign-in");
-  await page.getByLabel(/email/i).fill(user.email);
-  await page.getByLabel(/password/i).fill(user.password);
+  await page.getByLabel(/email/i).fill(credentials.email);
+  await page.getByLabel(/password/i).fill(credentials.password);
   await page.getByRole("button", { name: /^sign in$/i }).click();
   await expect(page).not.toHaveURL(/\/sign-in/);
 };
@@ -83,7 +93,9 @@ test("core student flows preserve mobile navigation and touch ergonomics", async
   await search.fill("Algorithms");
   await search.press("Enter");
   await expect(page).toHaveURL(/search=Algorithms/);
-  await expect(page.getByText("Algorithms", { exact: true }).first()).toBeVisible();
+  await expect(
+    page.getByText("Algorithms", { exact: true }).first(),
+  ).toBeVisible();
 
   const bottomSpacing = await page.evaluate(() => {
     const main = document.querySelector("main");
@@ -115,4 +127,64 @@ test("core student flows preserve mobile navigation and touch ergonomics", async
   await page.keyboard.press("Escape");
   await expect(page.getByRole("dialog", { name: "Account" })).not.toBeVisible();
   await expect(accountMenuTrigger).toBeFocused();
+});
+
+test("admin workspace uses a viewport-safe responsive navigation", async ({
+  page,
+}) => {
+  test.skip(
+    !admin.email || !admin.password,
+    "Set E2E_ADMIN_EMAIL and E2E_ADMIN_PASSWORD to run mobile admin checks",
+  );
+
+  await page.setViewportSize({ width: 360, height: 800 });
+  await signIn(page, admin);
+  await page.goto("/admin");
+  await expectNoHorizontalOverflow(page);
+
+  await expect(page.locator(".admin-sidebar")).toBeHidden();
+  const navigationTrigger = page.getByRole("button", {
+    name: "Open admin navigation",
+  });
+  const triggerBounds = await navigationTrigger.boundingBox();
+  expect(triggerBounds?.width ?? 0).toBeGreaterThanOrEqual(44);
+  expect(triggerBounds?.height ?? 0).toBeGreaterThanOrEqual(44);
+
+  await navigationTrigger.click();
+  const navigationDialog = page.getByRole("dialog", {
+    name: "Admin navigation",
+  });
+  await expect(navigationDialog).toBeVisible();
+  expect(
+    await navigationDialog.evaluate((element) => element.matches(":modal")),
+  ).toBe(true);
+  await expect(
+    navigationDialog.getByRole("link", { name: "Account Requests" }),
+  ).toBeVisible();
+  await expect(
+    navigationDialog.getByRole("link", { name: "Renewal Requests" }),
+  ).toBeVisible();
+
+  await navigationDialog
+    .getByRole("link", { name: "Account Requests" })
+    .click();
+  await expect(page).toHaveURL(/\/admin\/account-requests/);
+  await expect(navigationDialog).not.toBeVisible();
+
+  await page.setViewportSize({ width: 1024, height: 700 });
+  await page.goto("/admin");
+  await expect(page.locator(".admin-sidebar")).toBeVisible();
+  await expect(navigationTrigger).toBeHidden();
+
+  const sidebarGeometry = await page
+    .locator(".admin-sidebar")
+    .evaluate((element) => ({
+      top: element.getBoundingClientRect().top,
+      bottom: element.getBoundingClientRect().bottom,
+      height: element.getBoundingClientRect().height,
+      viewportHeight: window.innerHeight,
+    }));
+  expect(sidebarGeometry.top).toBe(0);
+  expect(sidebarGeometry.bottom).toBe(sidebarGeometry.viewportHeight);
+  expect(sidebarGeometry.height).toBe(sidebarGeometry.viewportHeight);
 });


### PR DESCRIPTION
## Summary
- replace the permanent mobile admin rail with an accessible native modal navigation drawer
- keep the desktop sidebar pinned to the dynamic viewport with a scrollable link region and fixed account footer
- share active-route navigation and account-card markup across desktop and mobile
- expose Renewal Requests with a distinct icon

## Scope
Admin shell navigation, responsive styling, navigation constants, one new SVG icon, and mobile E2E coverage. No database, API, authorization, or service-contract changes.

## Performance impact
The desktop sidebar is now server-rendered except for active-route links. No new third-party dependency was added. The production build and existing mobile JavaScript budgets pass.

## Security checklist
- [x] Existing server-side admin authorization remains unchanged
- [x] Native modal focus trapping and Escape dismissal retained
- [x] Body scroll lock is restored on close, route change, and desktop breakpoint transition
- [x] No secrets, new endpoints, or permission changes
- [x] CodeQL, repository security, dependency, and secret scans pass

## Deployment notes
No migration or environment-variable change is required. Standard Vercel deployment is sufficient; preview deployment is ready.

## Related issues
No linked issue. Fixes the reported admin sidebar viewport gap and mobile navigation behavior.

## Validation
- Node.js 24.18.0
- npm run lint
- npm run typecheck
- npm run test (127/127)
- npm run test:e2e:mobile (3/3), plus targeted breakpoint-transition rerun
- npm run build (mobile JavaScript budgets passed)
- rendered mobile and desktop visual inspection