### PR TITLE
fix: reject malformed upload media types

### DIFF
--- a/app/api/uploads/route.test.ts
+++ b/app/api/uploads/route.test.ts
@@ -109,6 +109,26 @@ describe("POST /api/uploads", () => {
     expect(upload).not.toHaveBeenCalled();
   });
 
+  it("rejects malformed upload media types without raising a server error", async () => {
+    const response = await POST(
+      new NextRequest("http://localhost/api/uploads", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost",
+        },
+        body: "{}",
+      }),
+    );
+
+    expect(response.status).toBe(415);
+    await expect(response.json()).resolves.toEqual({
+      error: "Upload requests must use multipart form data",
+    });
+    expect(requireAdmin).not.toHaveBeenCalled();
+    expect(upload).not.toHaveBeenCalled();
+  });
+
   it("rejects non-admin book media uploads before storage", async () => {
     requireAdmin.mockResolvedValue({ ok: false });
 

--- a/app/api/uploads/route.ts
+++ b/app/api/uploads/route.ts
@@ -129,6 +129,16 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const requestContentType = request.headers
+      .get("content-type")
+      ?.toLowerCase();
+    if (!requestContentType?.startsWith("multipart/form-data;")) {
+      return NextResponse.json(
+        { error: "Upload requests must use multipart form data" },
+        { status: 415 },
+      );
+    }
+
     const formData = await request.formData();
     const intentValue = formData.get("intent");
     const fileValue = formData.get("file");


### PR DESCRIPTION
## What changed

- Reject non-multipart upload requests with HTTP 415 before parsing the body.
- Add regression coverage for malformed JSON upload requests.

## Why

A bounded production rate-limit probe exposed that a same-origin request with `application/json` reached `request.formData()`, threw, and was converted into an HTTP 500. The endpoint should treat an unsupported request media type as a client error, not an origin failure.

## Impact

Malformed upload traffic now receives a controlled, non-sensitive response and no longer creates misleading server-error telemetry. Valid multipart uploads are unchanged.

## Validation

- `npm test -- --run app/api/uploads/route.test.ts`
- `npm run typecheck`
- `npm run lint`